### PR TITLE
Fix sprite gravity setter

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -473,7 +473,7 @@ class Sprite extends Drawable {
    * @memberof Sprite
    */
   setGravity(gravity) {
-    this.hitbox = hitbox;
+    this.gravity = gravity;
   }
 
   /**


### PR DESCRIPTION
## Summary
- fix gravity setter to assign gravity parameter

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840493f8cbc8326ace614f89357020b