### PR TITLE
Add sprite opacity control

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A lot! The engine includes:
 - Easy sprite creation
 - Movement and animation support (```sprite.XBy(1)``` or ```sprite.setX(1)```...etc)
 - Event handling (mouse, keyboard, etc.)
+- Sprite opacity control with `setOpacity()`
 - Scene and object management
 - And more!
 

--- a/src/game.js
+++ b/src/game.js
@@ -29,6 +29,7 @@
     player.startDrawing();       // leave a pen trail
     player.penColor = "cyan";
     player.penThickness = 2;
+    player.setOpacity(0.8);
   
     //   ground platform
     const ground = createSprite(canvaX/2, canvaY-30, "#654321");

--- a/src/library.js
+++ b/src/library.js
@@ -155,6 +155,8 @@ class Sprite extends Drawable {
     this.useOriginalSize = true;
     /** @type {number} Scaling factor for size */
     this.scale = 1.0;
+    /** @type {number} Opacity for rendering (0.0-1.0) */
+    this.opacity = 1.0;
     /** @type {Object|null} Control scheme for movement */
     this.controls = null;
     /** @type {number} Gravity effect in pixels per frame */
@@ -437,6 +439,22 @@ class Sprite extends Drawable {
   }
 
   /**
+   * Sets the sprite opacity.
+   * @param {number} alpha - Value between 0 and 1.
+   */
+  setOpacity(alpha) {
+    this.opacity = Math.max(0, Math.min(1, alpha));
+  }
+
+  /**
+   * Changes the sprite opacity by a delta.
+   * @param {number} delta - Amount to add to current opacity.
+   */
+  changeOpacityBy(delta) {
+    this.setOpacity(this.opacity + delta);
+  }
+
+  /**
    * Set the size(for no-image costume only!) of the sprite.
    *
    * @param {*} size - The size you want to set for your sprite.
@@ -622,6 +640,7 @@ class Sprite extends Drawable {
     if (this.hidden) return;
 
     ctx.save();
+    ctx.globalAlpha = this.opacity;
     ctx.translate(this.x, this.y); // move origin to sprite centre
     ctx.rotate(((this.direction - 90) * Math.PI) / 180); // Scratch’s 90°‑right → canvas 0°‑right
     // subtract 90 so 0° points up


### PR DESCRIPTION
## Summary
- support per-sprite opacity
- document opacity feature in README
- demo usage in `game.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840495999b88326a6a60d16bca02fb7